### PR TITLE
test(cloud): add TestAzure to verify AZURE mode

### DIFF
--- a/cloud_test.go
+++ b/cloud_test.go
@@ -34,6 +34,13 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
+func TestAzure(t *testing.T) {
+	cloud.SetMode(cloud.AZURE)
+	if cloud.Mode() != cloud.AZURE {
+		t.Errorf(errorResult, cloud.AZURE, cloud.Mode())
+	}
+}
+
 func TestUnknown(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
Add a unit test TestAzure in_test.go to set the cloud
 to AZURE and assert that Mode() returns cloud.AZURE.
This ensures the mode setter/getter behavior works for the
Azure provider and prevents regressions when modifying
cloud mode handling.