### PR TITLE
chore(go): bump Go to 1.25 and update CI configs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,20 +6,16 @@ on:
   pull_request:
     branches:
       - main
-
 permissions:
   contents: read
-
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
-
+          go-version: "1.25"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,8 @@ on:
   push:
     tags:
       - "*"
-
 permissions:
   contents: write
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
-
+          go-version: "1.25"
       - name: Test
         run: go run gotest.tools/gotestsum@latest --jsonfile go-test.json --format testname
-
       - name: Test Summary
         uses: dorny/test-reporter@v2
         if: ${{ !cancelled() }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 {
     "cSpell.words": [
-        "dotenv"
+        "dorny",
+        "dotenv",
+        "golangci",
+        "gomod",
+        "gotest",
+        "gotestsum",
+        "jsonfile",
+        "ncipollo",
+        "testname"
     ]
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Reflective-Technology/cloud
 
-go 1.24
+go 1.25


### PR DESCRIPTION
Add Go 1.25 across module and CI workflows and tidy related CI files.
- Update go.mod to require go 1.25 so builds use the newer toolchain.
- Update GitHub Actions setups (golangci-lint and test workflows) to use
  actions/setup-go@v5 with go-version 1.25 to keep runner Go version in
  sync with the module.
- Update golangci-lint workflow and test workflow to remove stray blank
  lines and ensure steps are properly ordered.
- Add common test tooling words to VSCode cSpell settings for local dev
  (dorny, golangci, gomod, gotest, gotestsum, jsonfile, ncipollo,
  testname) to reduce editor spelling noise.

These changes ensure CI and local development use a consistent Go version
and improve developer experience by reducing spurious linter/typo noise.