### PR TITLE
docs: expand README with usage features, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,63 @@
 # Cloud
 
-This is a Go package for cloud-related functionalities.
+This is a Go package for managing cloud modes, supporting AWS, GCP, Azure, and an unspecified mode.
 
-## Installation
+## Project Overview
 
-To install the package, use the following command:
+This package allows you to switch between cloud modes (`aws`, `gcp`, `azure`, `unspecified`) via environment variables or code, storing and retrieving the current cloud state in a thread-safe manner. It’s intended for Go applications that need to adjust behaviors according to their running environment.
+
+## Installation & Usage
+
+Install using the go get command:
 
 ```bash
 go get github.com/Reflective-Technology/cloud
 ```
 
+Import in your code:
+
+```go
+import "github.com/Reflective-Technology/cloud"
+```
+
+## Features
+
+- Automatically sets the current cloud mode based on the `CLOUD_MODE` environment variable
+- Supports AWS, GCP, Azure, and unspecified modes
+- Programmatically set mode: `cloud.SetMode("aws")`, `cloud.SetMode("gcp")`, `cloud.SetMode("azure")`
+- Get current mode: `cloud.Mode()`
+- Panics on unknown mode input to ensure correctness
+- Thread-safe implementation for concurrent environments
+
+## Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/Reflective-Technology/cloud"
+)
+
+func main() {
+    cloud.SetMode(cloud.AWS)
+    fmt.Println("Current cloud mode:", cloud.Mode()) // Output: aws
+
+    cloud.SetMode(cloud.GCP)
+    fmt.Println("Current cloud mode:", cloud.Mode()) // Output: gcp
+
+    cloud.SetMode("")
+    fmt.Println("Current cloud mode:", cloud.Mode()) // Output: unspecified
+}
+```
+
 ## Contributing
 
-If you would like to contribute to this project, please fork the repository and submit a pull request.
+1. Fork this project and create your own branch
+2. Submit a Pull Request after making changes
+3. Please describe your changes in detail in the PR
+4. This project is licensed under MIT License – contributions are welcome!
 
-## License
+---
 
-This project is licensed under the MIT License.
+For further documentation or support, please visit the [Reflective-Technology organization page](https://github.com/Reflective-Technology).


### PR DESCRIPTION
Revise README to provide a clear project overview, installation
instructions, usage examples, and a feature list. Add guidance for
importing and installing the package, document supported cloud modes
(aws, gcp, azure, unspecified), and show programmatic API examples
(SetMode, Mode). Describe behavior such as automatic mode detection
from the CLOUD_MODE environment variable, thread-safety, and the
panic on unknown mode inputs to emphasize correctness.

Improve contributing instructions and add a link to the organization
page for further documentation. Reformat sections and add an example
Go program demonstrating setting and reading the cloud mode.