### PR TITLE
feat(cloud): add on-premise cloud mode and code mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Cloud
 
-This is a Go package for managing cloud modes, supporting AWS, GCP, Azure, and an unspecified mode.
+This is a Go package for managing cloud modes, supporting AWS, GCP, Azure, On Premise, and an unspecified mode.
 
 ## Project Overview
 
-This package allows you to switch between cloud modes (`aws`, `gcp`, `azure`, `unspecified`) via environment variables or code, storing and retrieving the current cloud state in a thread-safe manner. It’s intended for Go applications that need to adjust behaviors according to their running environment.
+This package allows you to switch between cloud modes (`aws`, `gcp`, `azure`, `on-premise`, `unspecified`) via environment variables or code, storing and retrieving the current cloud state in a thread-safe manner. It’s intended for Go applications that need to adjust behaviors according to their running environment.
 
 ## Installation & Usage
 
@@ -23,8 +23,8 @@ import "github.com/Reflective-Technology/cloud"
 ## Features
 
 - Automatically sets the current cloud mode based on the `CLOUD_MODE` environment variable
-- Supports AWS, GCP, Azure, and unspecified modes
-- Programmatically set mode: `cloud.SetMode("aws")`, `cloud.SetMode("gcp")`, `cloud.SetMode("azure")`
+- Supports AWS, GCP, Azure, On Premise, and unspecified modes
+- Programmatically set mode: `cloud.SetMode("aws")`, `cloud.SetMode("gcp")`, `cloud.SetMode("azure")`, `cloud.SetMode("on-premise")`
 - Get current mode: `cloud.Mode()`
 - Panics on unknown mode input to ensure correctness
 - Thread-safe implementation for concurrent environments
@@ -45,6 +45,12 @@ func main() {
 
     cloud.SetMode(cloud.GCP)
     fmt.Println("Current cloud mode:", cloud.Mode()) // Output: gcp
+
+    cloud.SetMode(cloud.AZURE)
+    fmt.Println("Current cloud mode:", cloud.Mode()) // Output: azure
+
+    cloud.SetMode(cloud.ON_PREMISE)
+    fmt.Println("Current cloud mode:", cloud.Mode()) // Output: on-premise
 
     cloud.SetMode("")
     fmt.Println("Current cloud mode:", cloud.Mode()) // Output: unspecified

--- a/cloud.go
+++ b/cloud.go
@@ -11,6 +11,7 @@ const (
 	AWS         = "aws"
 	GCP         = "gcp"
 	AZURE       = "azure"
+	ON_PREMISE  = "on-premise"
 	UNSPECIFIED = "unspecified"
 )
 
@@ -18,6 +19,7 @@ const (
 	awsCode = iota
 	gcpCode
 	azureCode
+	onPremiseCode
 	unspecifiedCode
 )
 
@@ -44,6 +46,8 @@ func SetMode(value string) {
 		atomic.StoreInt32(&appMode, gcpCode)
 	case AZURE:
 		atomic.StoreInt32(&appMode, azureCode)
+	case ON_PREMISE:
+		atomic.StoreInt32(&appMode, onPremiseCode)
 	case UNSPECIFIED:
 		atomic.StoreInt32(&appMode, unspecifiedCode)
 	default:

--- a/cloud_test.go
+++ b/cloud_test.go
@@ -41,6 +41,13 @@ func TestAzure(t *testing.T) {
 	}
 }
 
+func TestOnPremise(t *testing.T) {
+	cloud.SetMode(cloud.ON_PREMISE)
+	if cloud.Mode() != cloud.ON_PREMISE {
+		t.Errorf(errorResult, cloud.ON_PREMISE, cloud.Mode())
+	}
+}
+
 func TestUnknown(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
Introduce a new cloud constant ON_PREMISE and corresponding internal
enum value onPremiseCode. Wire the new mode into the appMode switch
so that selecting "on-premise" sets the correct internal code via
atomic.StoreInt32.

This enables the application to recognize and handle on-premise
deployments consistently alongside AWS, GCP, and Azure.