### PR TITLE
ci: add explicit read permissions to workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,9 +13,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: "1.25"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -38,12 +38,13 @@ jobs:
         uses: actions/checkout@v5
       - name: Push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: "v"
           custom_tag: ${{ needs.version.outputs.version }}
-      - uses: ncipollo/release-action@v1
+      - name: Create Release
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
         with:
           generateReleaseNotes: true
           skipIfReleaseExists: true

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -7,6 +7,8 @@ on:
       - "VERSION"
 jobs:
   version:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Test
         run: go run gotest.tools/gotestsum@latest --jsonfile go-test.json --format testname
       - name: Test Summary
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f
         if: ${{ !cancelled() }}
         with:
           name: test-results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add explicit contents read permissions to GitHub Actions
workflows to follow security best practices and ensure
workflows have minimal required permissions.